### PR TITLE
Required updates for `p2panda-js` `0.6.0` and GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Updates for breaking `p2panda-js` API changes [#4](https://github.com/p2panda/shirokuma/pull/4)
+
 [unreleased]: https://github.com/p2panda/shirokuma/compare/...HEAD

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "^4.3.4",
         "graphql": "^16.5.0",
         "graphql-request": "^4.3.0",
-        "p2panda-js": "^0.5.0"
+        "p2panda-js": "^0.6.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.18.10",
@@ -8127,9 +8127,9 @@
       }
     },
     "node_modules/p2panda-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/p2panda-js/-/p2panda-js-0.5.0.tgz",
-      "integrity": "sha512-JjQNXzg3GAle7xahiG17zAYK186Ec4UeGFuc7Dnxca+DXB+K3y1uApDkiKoqegMmY8bOy6QMpGNuQzyAd21EjQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/p2panda-js/-/p2panda-js-0.6.0.tgz",
+      "integrity": "sha512-/DF7xQeBgXoamZyZJNFMN7FVoPEG9hKpUsugquiN3nGmXYWYfvgeXuxXWU0z0qww4DL3+MZgU+Dz3D2Ri/EmAw==",
       "engines": {
         "node": ">= v16.0.0"
       }
@@ -15777,9 +15777,9 @@
       "dev": true
     },
     "p2panda-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/p2panda-js/-/p2panda-js-0.5.0.tgz",
-      "integrity": "sha512-JjQNXzg3GAle7xahiG17zAYK186Ec4UeGFuc7Dnxca+DXB+K3y1uApDkiKoqegMmY8bOy6QMpGNuQzyAd21EjQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/p2panda-js/-/p2panda-js-0.6.0.tgz",
+      "integrity": "sha512-/DF7xQeBgXoamZyZJNFMN7FVoPEG9hKpUsugquiN3nGmXYWYfvgeXuxXWU0z0qww4DL3+MZgU+Dz3D2Ri/EmAw=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "debug": "^4.3.4",
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
-    "p2panda-js": "^0.5.0"
+    "p2panda-js": "^0.6.0"
   }
 }

--- a/src/document/document.test.ts
+++ b/src/document/document.test.ts
@@ -56,11 +56,11 @@ describe('document', () => {
       // These are the fields for an update operation
       const fields = entryFixture(2).operation?.fields as Fields;
 
-      const previousOperations = entryFixture(2).operation
-        ?.previous_operations as string[];
+      const previous = entryFixture(2).operation
+        ?.previous as string[];
 
       const entryEncoded = await updateDocument(
-        previousOperations,
+        previous,
         fields,
         {
           keyPair,
@@ -84,10 +84,10 @@ describe('document', () => {
         .mockResolvedValue(entryArgsFixture(4));
       jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
-      const previousOperations = entryFixture(4).operation
-        ?.previous_operations as string[];
+      const previous = entryFixture(4).operation
+        ?.previous as string[];
 
-      const entryEncoded = await deleteDocument(previousOperations, {
+      const entryEncoded = await deleteDocument(previous, {
         keyPair,
         schema: schemaFixture(),
         session,

--- a/src/document/document.test.ts
+++ b/src/document/document.test.ts
@@ -8,7 +8,6 @@ import type { Fields } from '../types';
 
 import {
   authorFixture,
-  documentIdFixture,
   entryFixture,
   encodedEntryFixture,
   entryArgsFixture,
@@ -57,14 +56,10 @@ describe('document', () => {
       // These are the fields for an update operation
       const fields = entryFixture(2).operation?.fields as Fields;
 
-      // This is the document id
-      const id = documentIdFixture();
-
       const previousOperations = entryFixture(2).operation
         ?.previous_operations as string[];
 
       const entryEncoded = await updateDocument(
-        id,
         previousOperations,
         fields,
         {
@@ -89,13 +84,10 @@ describe('document', () => {
         .mockResolvedValue(entryArgsFixture(4));
       jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
-      // This is the document id
-      const id = documentIdFixture();
-
       const previousOperations = entryFixture(4).operation
         ?.previous_operations as string[];
 
-      const entryEncoded = await deleteDocument(id, previousOperations, {
+      const entryEncoded = await deleteDocument(previousOperations, {
         keyPair,
         schema: schemaFixture(),
         session,

--- a/src/document/document.test.ts
+++ b/src/document/document.test.ts
@@ -56,18 +56,13 @@ describe('document', () => {
       // These are the fields for an update operation
       const fields = entryFixture(2).operation?.fields as Fields;
 
-      const previous = entryFixture(2).operation
-        ?.previous as string[];
+      const previous = entryFixture(2).operation?.previous as string[];
 
-      const entryEncoded = await updateDocument(
-        previous,
-        fields,
-        {
-          keyPair,
-          schema: schemaFixture(),
-          session,
-        },
-      );
+      const entryEncoded = await updateDocument(previous, fields, {
+        keyPair,
+        schema: schemaFixture(),
+        session,
+      });
 
       expect(entryEncoded).toEqual(encodedEntryFixture(2).entryBytes);
     });
@@ -84,8 +79,7 @@ describe('document', () => {
         .mockResolvedValue(entryArgsFixture(4));
       jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
-      const previous = entryFixture(4).operation
-        ?.previous as string[];
+      const previous = entryFixture(4).operation?.previous as string[];
 
       const entryEncoded = await deleteDocument(previous, {
         keyPair,

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -48,12 +48,12 @@ export const createDocument = async (
  * Returns the encoded entry that was created.
  */
 export const updateDocument = async (
-  previousOperations: string[],
+  previous: string[],
   fields: Fields,
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
   log(`Updating document view`, {
-    previousOperations,
+    previous,
     fields,
   });
 
@@ -63,7 +63,7 @@ export const updateDocument = async (
   const encodedOperation = encodeOperation({
     action: 'update',
     schemaId: schema,
-    previousOperations,
+    previous,
     fields: operationFields,
   });
 
@@ -74,7 +74,7 @@ export const updateDocument = async (
       schema,
       session,
     },
-    previousOperations,
+    previous,
   );
 
   return entryEncoded;
@@ -86,15 +86,15 @@ export const updateDocument = async (
  * Returns the encoded entry that was created.
  */
 export const deleteDocument = async (
-  previousOperations: string[],
+  previous: string[],
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
-  log('Deleting document with view ', { previousOperations });
+  log('Deleting document with view ', { previous });
 
   const encodedOperation = encodeOperation({
     action: 'delete',
     schemaId: schema,
-    previousOperations,
+    previous,
   });
 
   const encodedEntry = await signPublishEntry(
@@ -104,7 +104,7 @@ export const deleteDocument = async (
       schema,
       session,
     },
-    previousOperations,
+    previous,
   );
 
   return encodedEntry;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -48,13 +48,11 @@ export const createDocument = async (
  * Returns the encoded entry that was created.
  */
 export const updateDocument = async (
-  documentId: string,
   previousOperations: string[],
   fields: Fields,
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
-  log(`Updating document`, {
-    document: documentId,
+  log(`Updating document view`, {
     previousOperations,
     fields,
   });
@@ -76,7 +74,7 @@ export const updateDocument = async (
       schema,
       session,
     },
-    documentId,
+    previousOperations,
   );
 
   return entryEncoded;
@@ -88,11 +86,10 @@ export const updateDocument = async (
  * Returns the encoded entry that was created.
  */
 export const deleteDocument = async (
-  documentId: string,
   previousOperations: string[],
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
-  log('Deleting document', { document: documentId, previousOperations });
+  log('Deleting document with view ', { previousOperations });
 
   const encodedOperation = encodeOperation({
     action: 'delete',
@@ -107,7 +104,7 @@ export const deleteDocument = async (
       schema,
       session,
     },
-    documentId,
+    previousOperations,
   );
 
   return encodedEntry;

--- a/src/entry/entry.ts
+++ b/src/entry/entry.ts
@@ -18,16 +18,17 @@ const log = debug('shirokuma:entry');
 export const signPublishEntry = async (
   operationEncoded: string,
   { keyPair, session }: Context,
-  documentId?: string,
+  viewId?: string[],
 ): Promise<string> => {
   const publicKey = keyPair.publicKey();
+  const viewIdStr = viewId ? viewId.join('_') : undefined;
 
   log('Signing and publishing entry');
-  const nextArgs = await session.getNextArgs(publicKey, documentId);
+  const nextArgs = await session.getNextArgs(publicKey, viewIdStr);
 
   log('Retrieved next args for', {
     publicKey,
-    documentId,
+    viewId,
     nextArgs,
   });
 
@@ -46,7 +47,7 @@ export const signPublishEntry = async (
 
   // Cache next entry args for next publish. Use the entry hash as the document
   // id for CREATE operations.
-  session.setNextArgs(publicKey, documentId || entryHash, publishNextArgs);
+  session.setNextArgs(publicKey, entryHash, publishNextArgs);
   log('Cached next arguments');
 
   return entryEncoded;

--- a/src/entry/entry.ts
+++ b/src/entry/entry.ts
@@ -16,7 +16,7 @@ const log = debug('shirokuma:entry');
  * Returns the encoded entry.
  */
 export const signPublishEntry = async (
-  operationEncoded: string,
+  operation: string,
   { keyPair, session }: Context,
   viewId?: string[],
 ): Promise<string> => {
@@ -32,17 +32,17 @@ export const signPublishEntry = async (
     nextArgs,
   });
 
-  const entryEncoded = signAndEncodeEntry(
+  const entry = signAndEncodeEntry(
     {
       ...nextArgs,
-      operation: operationEncoded,
+      operation,
     },
     keyPair,
   );
-  const entryHash = generateHash(entryEncoded);
+  const entryHash = generateHash(entry);
   log('Signed and encoded entry');
 
-  const publishNextArgs = await session.publish(entryEncoded, operationEncoded);
+  const publishNextArgs = await session.publish(entry, operation);
   log('Published entry');
 
   // Cache next entry args for next publish. Use the entry hash as the document
@@ -50,5 +50,5 @@ export const signPublishEntry = async (
   session.setNextArgs(publicKey, entryHash, publishNextArgs);
   log('Cached next arguments');
 
-  return entryEncoded;
+  return entry;
 };

--- a/src/entry/entry.ts
+++ b/src/entry/entry.ts
@@ -45,8 +45,7 @@ export const signPublishEntry = async (
   const publishNextArgs = await session.publish(entry, operation);
   log('Published entry');
 
-  // Cache next entry args for next publish. Use the entry hash as the document
-  // id for CREATE operations.
+  // Cache next entry args for next publish.
   session.setNextArgs(publicKey, entryHash, publishNextArgs);
   log('Cached next arguments');
 

--- a/src/entry/entry.ts
+++ b/src/entry/entry.ts
@@ -35,7 +35,7 @@ export const signPublishEntry = async (
   const entryEncoded = signAndEncodeEntry(
     {
       ...nextArgs,
-      payload: operationEncoded,
+      operation: operationEncoded,
     },
     keyPair,
   );

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -205,8 +205,8 @@ describe('Session', () => {
     const fields = entryFixture(2).operation?.fields as Fields;
 
     // These are the previous operations
-    const previousOperations = entryFixture(2).operation
-      ?.previous_operations as string[];
+    const previous = entryFixture(2).operation
+      ?.previous as string[];
 
     beforeEach(async () => {
       session = new Session('http://localhost:2020');
@@ -216,7 +216,7 @@ describe('Session', () => {
 
     it('handles valid arguments', async () => {
       expect(
-        await session.update(fields, previousOperations, {
+        await session.update(fields, previous, {
           schema: schemaFixture(),
         }),
       ).resolves;
@@ -224,7 +224,7 @@ describe('Session', () => {
       expect(
         await session
           .setSchema(schemaFixture())
-          .update(fields, previousOperations),
+          .update(fields, previous),
       ).resolves;
     });
 
@@ -244,8 +244,8 @@ describe('Session', () => {
     let session: Session;
 
     // These are the previous operations
-    const previousOperations = entryFixture(2).operation
-      ?.previous_operations as string[];
+    const previous = entryFixture(2).operation
+      ?.previous as string[];
 
     beforeEach(async () => {
       session = new Session('http://localhost:2020');
@@ -255,11 +255,11 @@ describe('Session', () => {
 
     it('handles valid arguments', async () => {
       expect(
-        session.delete(previousOperations, {
+        session.delete(previous, {
           schema: schemaFixture(),
         }),
       ).resolves;
-      expect(session.setSchema(schemaFixture()).delete(previousOperations))
+      expect(session.setSchema(schemaFixture()).delete(previous))
         .resolves;
     });
 
@@ -271,7 +271,7 @@ describe('Session', () => {
 
       expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.delete(previousOperations),
+        session.delete(previous),
       ).rejects.toThrow();
     });
   });

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -205,8 +205,7 @@ describe('Session', () => {
     const fields = entryFixture(2).operation?.fields as Fields;
 
     // These are the previous operations
-    const previous = entryFixture(2).operation
-      ?.previous as string[];
+    const previous = entryFixture(2).operation?.previous as string[];
 
     beforeEach(async () => {
       session = new Session('http://localhost:2020');
@@ -221,11 +220,8 @@ describe('Session', () => {
         }),
       ).resolves;
 
-      expect(
-        await session
-          .setSchema(schemaFixture())
-          .update(fields, previous),
-      ).resolves;
+      expect(await session.setSchema(schemaFixture()).update(fields, previous))
+        .resolves;
     });
 
     it('throws when missing a required parameter', async () => {
@@ -244,8 +240,7 @@ describe('Session', () => {
     let session: Session;
 
     // These are the previous operations
-    const previous = entryFixture(2).operation
-      ?.previous as string[];
+    const previous = entryFixture(2).operation?.previous as string[];
 
     beforeEach(async () => {
       session = new Session('http://localhost:2020');
@@ -259,8 +254,7 @@ describe('Session', () => {
           schema: schemaFixture(),
         }),
       ).resolves;
-      expect(session.setSchema(schemaFixture()).delete(previous))
-        .resolves;
+      expect(session.setSchema(schemaFixture()).delete(previous)).resolves;
     });
 
     it('throws when missing a required parameter', async () => {

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -18,8 +18,8 @@ import {
 } from '../../test/fixtures';
 
 /* Set up GraphQL server mock. It will respond to:
- * - query `nextEntryArgs`: always returns entry args for sequence number 6
- * - mutation `publishEntry` always returns a response as if sequence
+ * - query `nextArgs`: always returns entry args for sequence number 6
+ * - mutation `publish` always returns a response as if sequence
  *   number 5 had been published. */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('node-fetch', () => require('fetch-mock-jest').sandbox());
@@ -38,7 +38,7 @@ fetchMock
     },
     {
       data: {
-        nextEntryArgs: entryArgsFixture(5),
+        nextArgs: entryArgsFixture(5),
       },
     },
   )
@@ -50,7 +50,7 @@ fetchMock
     },
     {
       data: {
-        publishEntry: entryArgsFixture(5),
+        publish: entryArgsFixture(5),
       },
     },
   );
@@ -123,7 +123,7 @@ describe('Session', () => {
     });
   });
 
-  describe('get/setNextEntryArgs', () => {
+  describe('get/setnextArgs', () => {
     it('returns next entry args from node', async () => {
       const session = new Session('http://localhost:2020');
 

--- a/src/session/session.test.ts
+++ b/src/session/session.test.ts
@@ -204,9 +204,6 @@ describe('Session', () => {
     // These are the fields for an update operation
     const fields = entryFixture(2).operation?.fields as Fields;
 
-    // This is the document id
-    const documentId = documentIdFixture();
-
     // These are the previous operations
     const previousOperations = entryFixture(2).operation
       ?.previous_operations as string[];
@@ -219,7 +216,7 @@ describe('Session', () => {
 
     it('handles valid arguments', async () => {
       expect(
-        await session.update(documentId, fields, previousOperations, {
+        await session.update(fields, previousOperations, {
           schema: schemaFixture(),
         }),
       ).resolves;
@@ -227,31 +224,24 @@ describe('Session', () => {
       expect(
         await session
           .setSchema(schemaFixture())
-          .update(documentId, fields, previousOperations),
+          .update(fields, previousOperations),
       ).resolves;
     });
 
     it('throws when missing a required parameter', async () => {
       await expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.update(null, fields, { schema: schemaFixture() }),
+        session.update(null, { schema: schemaFixture() }),
       ).rejects.toThrow();
       await expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.update(documentId, null, { schema: schemaFixture() }),
-      ).rejects.toThrow();
-      await expect(
-        // @ts-ignore: We deliberately use the API wrong here
-        session.update(documentId, fields),
+        session.update(fields),
       ).rejects.toThrow();
     });
   });
 
   describe('delete', () => {
     let session: Session;
-
-    // This is the document id that can be deleted
-    const documentId = documentIdFixture();
 
     // These are the previous operations
     const previousOperations = entryFixture(2).operation
@@ -265,15 +255,12 @@ describe('Session', () => {
 
     it('handles valid arguments', async () => {
       expect(
-        session.delete(documentId, previousOperations, {
+        session.delete(previousOperations, {
           schema: schemaFixture(),
         }),
       ).resolves;
-      expect(
-        session
-          .setSchema(schemaFixture())
-          .delete(documentId, previousOperations),
-      ).resolves;
+      expect(session.setSchema(schemaFixture()).delete(previousOperations))
+        .resolves;
     });
 
     it('throws when missing a required parameter', async () => {
@@ -284,7 +271,7 @@ describe('Session', () => {
 
       expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.delete(documentId),
+        session.delete(previousOperations),
       ).rejects.toThrow();
     });
   });

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -22,10 +22,9 @@ type NextArgsVariables = {
 };
 
 // GraphQL query to retrieve next entry args from node.
-// @TODO: Query `nextEntryArgs` is deprecated and will be replaced by `nextArgs` soon
 export const GQL_NEXT_ARGS = gql`
   query NextArgs($publicKey: String!, $viewId: String) {
-    nextEntryArgs(publicKey: $publicKey, documentId: $viewId) {
+    nextArgs(publicKey: $publicKey, viewId: $viewId) {
       logId
       seqNum
       backlink
@@ -42,10 +41,9 @@ type PublishVariables = {
 // GraphQL mutation to publish an entry and retrieve arguments for encoding the
 // next operation on the same document (those are currently not used to update
 // the next entry arguments cache).
-// @TODO: Query `publishEntry` is deprecated and will be replaced by `publish` soon
 export const GQL_PUBLISH = gql`
   mutation Publish($entry: String!, $operation: String!) {
-    publishEntry(entry: $entry, operation: $operation) {
+    publish(entry: $entry, operation: $operation) {
       logId
       seqNum
       backlink
@@ -145,7 +143,7 @@ export class Session {
   /**
    * Return arguments for constructing the next entry given author and schema.
    *
-   * This uses the cache set through `Session._setNextEntryArgs`.
+   * This uses the cache set through `Session._setnextArgs`.
    *
    * @param publicKey public key of the author
    * @param viewId optional document view id
@@ -176,8 +174,8 @@ export class Session {
 
     try {
       const data = await this.client.request(GQL_NEXT_ARGS, variables);
-      // @TODO: Query `nextEntryArgs` is deprecated and will be replaced by `nextArgs` soon
-      const nextArgs = data.nextEntryArgs;
+      // @TODO: Query `nextArgs` is deprecated and will be replaced by `nextArgs` soon
+      const nextArgs = data.nextArgs;
       log('request nextArgs', nextArgs);
       return nextArgs;
     } catch (err) {
@@ -217,12 +215,12 @@ export class Session {
 
     try {
       const data = await this.client.request(GQL_PUBLISH, variables);
-      log('request publishEntry', data);
-      // @TODO: Query `publishEntry` is deprecated and will be replaced by `publish` soon
-      if (data?.publishEntry == null) {
-        throw new Error("Response doesn't contain field `publishEntry`");
+      log('request publish', data);
+      // @TODO: Query `publish` is deprecated and will be replaced by `publish` soon
+      if (data?.publish == null) {
+        throw new Error("Response doesn't contain field `publish`");
       }
-      return data.publishEntry;
+      return data.publish;
     } catch (err) {
       log('Error publishing entry');
       throw err;

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -277,7 +277,7 @@ export class Session {
    *
    * @param documentId id of the document we update, this is the id of the root `create` operation
    * @param fields application data to publish with the new entry, needs to match schema
-   * @param previousOperations array of operation ids identifying the tips of all currently un-merged branches in the document graph
+   * @param previous array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id
@@ -286,20 +286,20 @@ export class Session {
    * const operationFields = {
    *   message: 'ahoy',
    * };
-   * const previousOperations = [
+   * const previous = [
    *   '00203341c9dd226525886ee77c95127cd12f74366703e02f9b48f3561a9866270f07',
    * ];
    * await new Session(endpoint)
    *   .setKeyPair(keyPair)
-   *   .update(documentId, operationFields, previousOperations, { schema });
+   *   .update(documentId, operationFields, previous, { schema });
    */
   async update(
     fields: Fields,
-    previousOperations: string[],
+    previous: string[],
     options?: Partial<Context>,
   ): Promise<Session> {
     // We should validate the data against the schema here too eventually
-    if (!previousOperations) {
+    if (!previous) {
       throw new Error('Previous view id must be provided');
     }
 
@@ -307,13 +307,13 @@ export class Session {
       throw new Error('Operation fields must be provided');
     }
 
-    log('update document wyth view ', previousOperations, fields);
+    log('update document wyth view ', previous, fields);
     const mergedOptions = {
       schema: options?.schema || this.schema,
       keyPair: options?.keyPair || this.keyPair,
       session: this,
     };
-    updateDocument(previousOperations, fields, mergedOptions);
+    updateDocument(previous, fields, mergedOptions);
 
     return this;
   }
@@ -327,34 +327,34 @@ export class Session {
    * Caches arguments for creating the next entry of this schema in the given session.
    *
    * @param documentId id of the document we delete, this is the hash of the root `create` entry
-   * @param previousOperations array of operation ids identifying the tips of all currently un-merged branches in the document graph
+   * @param previous array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id
    * @example
    * const documentId = '00200cf84048b0798942deba7b1b9fcd77ca72876643bd3fedfe612d4c6fb60436be';
-   * const previousOperations = [
+   * const previous = [
    *   '00203341c9dd226525886ee77c95127cd12f74366703e02f9b48f3561a9866270f07',
    * ];
    * await new Session(endpoint)
    *   .setKeyPair(keyPair)
-   *   .delete(documentId, previousOperations, { schema });
+   *   .delete(documentId, previous, { schema });
    */
   async delete(
-    previousOperations: string[],
+    previous: string[],
     options?: Partial<Context>,
   ): Promise<Session> {
-    if (!previousOperations) {
+    if (!previous) {
       throw new Error('Previous view id must be provided');
     }
 
-    log('delete document with view ', previousOperations);
+    log('delete document with view ', previous);
     const mergedOptions = {
       schema: options?.schema || this.schema,
       keyPair: options?.keyPair || this.keyPair,
       session: this,
     };
-    deleteDocument(previousOperations, mergedOptions);
+    deleteDocument(previous, mergedOptions);
 
     return this;
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -294,27 +294,26 @@ export class Session {
    *   .update(documentId, operationFields, previousOperations, { schema });
    */
   async update(
-    documentId: string,
     fields: Fields,
     previousOperations: string[],
     options?: Partial<Context>,
   ): Promise<Session> {
     // We should validate the data against the schema here too eventually
-    if (!documentId) {
-      throw new Error('Document id must be provided');
+    if (!previousOperations) {
+      throw new Error('Previous view id must be provided');
     }
 
     if (!fields) {
       throw new Error('Operation fields must be provided');
     }
 
-    log('update document', documentId, fields);
+    log('update document wyth view ', previousOperations, fields);
     const mergedOptions = {
       schema: options?.schema || this.schema,
       keyPair: options?.keyPair || this.keyPair,
       session: this,
     };
-    updateDocument(documentId, previousOperations, fields, mergedOptions);
+    updateDocument(previousOperations, fields, mergedOptions);
 
     return this;
   }
@@ -342,21 +341,20 @@ export class Session {
    *   .delete(documentId, previousOperations, { schema });
    */
   async delete(
-    documentId: string,
     previousOperations: string[],
     options?: Partial<Context>,
   ): Promise<Session> {
-    if (!documentId) {
-      throw new Error('Document id must be provided');
+    if (!previousOperations) {
+      throw new Error('Previous view id must be provided');
     }
 
-    log('delete document', documentId);
+    log('delete document with view ', previousOperations);
     const mergedOptions = {
       schema: options?.schema || this.schema,
       keyPair: options?.keyPair || this.keyPair,
       session: this,
     };
-    deleteDocument(documentId, previousOperations, mergedOptions);
+    deleteDocument(previousOperations, mergedOptions);
 
     return this;
   }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -269,20 +269,18 @@ export class Session {
    * Signs and publishes an UPDATE operation for the given application data and
    * matching schema.
    *
-   * The document to be updated is referenced by its document id, which is the
-   * operation id of that document's initial `CREATE` operation.
+   * The document to be updated is identified by the `previous` parameter which contains
+   * the most recent known document view id.
    *
    * Caches arguments for creating the next entry of this schema in the given
    * session.
    *
-   * @param documentId id of the document we update, this is the id of the root `create` operation
    * @param fields application data to publish with the new entry, needs to match schema
    * @param previous array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id
    * @example
-   * const documentId = '00200cf84048b0798942deba7b1b9fcd77ca72876643bd3fedfe612d4c6fb60436be';
    * const operationFields = {
    *   message: 'ahoy',
    * };
@@ -291,7 +289,7 @@ export class Session {
    * ];
    * await new Session(endpoint)
    *   .setKeyPair(keyPair)
-   *   .update(documentId, operationFields, previous, { schema });
+   *   .update(operationFields, previous, { schema });
    */
   async update(
     fields: Fields,
@@ -321,24 +319,22 @@ export class Session {
   /**
    * Signs and publishes a DELETE operation for the given schema.
    *
-   * The document to be deleted is referenced by its document id, which is the
-   * operation id of that document's initial `CREATE` operation.
+   * The document to be deleted is identified by the `previous` parameter
+   * which contains the most recent known document view id.
    *
    * Caches arguments for creating the next entry of this schema in the given session.
    *
-   * @param documentId id of the document we delete, this is the hash of the root `create` entry
    * @param previous array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id
    * @example
-   * const documentId = '00200cf84048b0798942deba7b1b9fcd77ca72876643bd3fedfe612d4c6fb60436be';
    * const previous = [
    *   '00203341c9dd226525886ee77c95127cd12f74366703e02f9b48f3561a9866270f07',
    * ];
    * await new Session(endpoint)
    *   .setKeyPair(keyPair)
-   *   .delete(documentId, previous, { schema });
+   *   .delete(previous, { schema });
    */
   async delete(
     previous: string[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type Entry = {
 export type Operation = {
   action: 'create' | 'update' | 'delete';
   schema: SchemaId;
-  previous_operations?: string[];
+  previous?: string[];
   fields?: Fields;
   id?: string;
 };
@@ -98,7 +98,7 @@ export type EntryTagged = {
  */
 export type OperationTagged = {
   action: 'create' | 'update' | 'delete';
-  previous_operations?: string[];
+  previous?: string[];
   schema: SchemaId;
   fields: FieldsTagged;
 };

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -16,7 +16,7 @@ import TEST_DATA from './test-data.json';
 // Right now we only have one author `panda` who only has one schema log. This
 // could be expanded in the future.
 const encodedEntries = TEST_DATA.panda.logs[0].encodedEntries;
-const nextEntryArgs = TEST_DATA.panda.logs[0].nextEntryArgs;
+const nextArgs = TEST_DATA.panda.logs[0].nextArgs;
 
 // Convert JSON-imported operations to use `Map`s instead of objects for
 // reporesenting operation fields.
@@ -89,10 +89,10 @@ export const entryFixture = (seqNum: number): Entry => {
   }
 
   const entry: Entry = {
-    backlink: nextEntryArgs[index].backlink as string | undefined,
-    skiplink: nextEntryArgs[index].skiplink as string | undefined,
-    seqNum: BigInt(nextEntryArgs[index].seqNum),
-    logId: BigInt(nextEntryArgs[index].logId),
+    backlink: nextArgs[index].backlink as string | undefined,
+    skiplink: nextArgs[index].skiplink as string | undefined,
+    seqNum: BigInt(nextArgs[index].seqNum),
+    logId: BigInt(nextArgs[index].logId),
     operation,
   };
 
@@ -128,10 +128,10 @@ export const entryArgsFixture = (seqNum: number): NextArgs => {
   const index = seqNum - 1;
 
   const entryArgs: NextArgs = {
-    backlink: (nextEntryArgs[index].backlink || null) as string | undefined,
-    skiplink: (nextEntryArgs[index].skiplink || null) as string | undefined,
-    seqNum: nextEntryArgs[index].seqNum,
-    logId: nextEntryArgs[index].logId,
+    backlink: (nextArgs[index].backlink || null) as string | undefined,
+    skiplink: (nextArgs[index].skiplink || null) as string | undefined,
+    seqNum: nextArgs[index].seqNum,
+    logId: nextArgs[index].logId,
   };
 
   return entryArgs;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -83,9 +83,9 @@ export const entryFixture = (seqNum: number): Entry => {
     fields: fields,
   };
 
-  if (decodedOperations[index].previous_operations) {
-    operation.previous_operations =
-      decodedOperations[index].previous_operations;
+  if (decodedOperations[index].previous) {
+    operation.previous =
+      decodedOperations[index].previous;
   }
 
   const entry: Entry = {

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -55,7 +55,7 @@
             "action": "update",
             "schema": "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
             "version": 1,
-            "previous_operations": [
+            "previous": [
               "00201c221b573b1e0c67c5e2c624a93419774cdf46b3d62414c44a698df1237b1c16"
             ],
             "fields": {
@@ -66,7 +66,7 @@
             "action": "update",
             "schema": "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
             "version": 1,
-            "previous_operations": [
+            "previous": [
               "0020b7188ef505c499bf6d2d4a121e0535285fd444105b3d0b141429880bbb6cf31b"
             ],
             "fields": {
@@ -77,7 +77,7 @@
             "action": "delete",
             "schema": "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
             "version": 1,
-            "previous_operations": [
+            "previous": [
               "0020a93a4c8b92b4c4e15bd38703a806015bc9f1e72d93e577a29ed73b09bcf9a2b5"
             ]
           }

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -82,7 +82,7 @@
             ]
           }
         ],
-        "nextEntryArgs": [
+        "nextArgs": [
           {
             "backlink": null,
             "skiplink": null,


### PR DESCRIPTION
- update GraphQL API
- bump p2panda-js to 0.6.0
- bonus: don't use `documentId` when `previous` is enough

closes: #3 #2 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
