### PR TITLE
Introduce method for publishing blobs to `Session`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- introduce method for creating blobs to `Session` [#28](https://github.com/p2panda/shirokuma/pull/28)
+
 ## [0.1.2]
 
 > Released on 2023-11-16 :package:

--- a/src/session.ts
+++ b/src/session.ts
@@ -413,7 +413,32 @@ export class Session {
   }
 
   /**
-   * Create a blob document.
+   * Publish a blob.
+   * 
+   * The blob byte array is split into 256kb long pieces which are each published
+   * individually, following this the blob document itself is published. Included
+   * metadata is `mime_type` [str] and `length` [int] representing the complete
+   * byte length of the blob file.
+   * 
+   * @param blob - blob data to be published
+   * @param options - overrides globally set options for this method call
+   * @param options.keyPair - will be used to sign the new entry
+   * @returns Document id of the blob we've created
+   * @example
+   * ```
+   * const endpoint = 'http://localhost:2020/graphql';
+   * const keyPair = new KeyPair();
+   *
+   *
+   * const session = await new Session(endpoint)
+   *   .setKeyPair(keyPair)
+   *   .create(fields, { schemaId });
+   * 
+   * const input = document.querySelector('input');
+   * const blob = input.files[0];
+   * await session.createBlob(blob);
+   * ```
+
    */
   async createBlob(
     blob: Blob,

--- a/src/session.ts
+++ b/src/session.ts
@@ -429,7 +429,6 @@ export class Session {
    * const endpoint = 'http://localhost:2020/graphql';
    * const keyPair = new KeyPair();
    *
-   *
    * const session = await new Session(endpoint)
    *   .setKeyPair(keyPair)
    *   .create(fields, { schemaId });
@@ -452,7 +451,7 @@ export class Session {
     const bytes = await intoBytes(blob);
     const keyPair = options?.keyPair || this.keyPair;
 
-    // Retreive next entry arguments
+    // Retrieve next entry arguments
     const publicKey = keyPair.publicKey();
 
     const pieces = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export type DocumentViewId = string | string[];
 export type SchemaId =
   | 'schema_definition_v1'
   | 'schema_field_definition_v1'
+  | 'blob_v1'
+  | 'blob_piece_v1'
   | string;
 
 /**


### PR DESCRIPTION
When publishing a blob several steps are required:
- split the blob data array into pieces which are at most 256kb
- publish each of these pieces and add their document ids to a "pieces" list
- using the above pieces list, publish the blob and include metadata "mime type" and "length"

This PR introduces a new method onto `Session`: `createBlob` which accepts a `Blob` and takes care of the above steps for you.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
